### PR TITLE
Implement reprojection logic

### DIFF
--- a/pyba/Camera.py
+++ b/pyba/Camera.py
@@ -156,17 +156,28 @@ class Camera:
 
         """
         img = self.get_image(img_id)
-        points = self.points2d[img_id] if points is None else points[[img_id]]
-        if points.shape[-1] == 3:  # If 3D points are given, project them
-            points = self.project(points).squeeze()
+
+        if points is None:
+            
+            points = self.points2d[img_id]
+
+        if points.shape[-1] == 3:
+            # points are given as 3d coords
+            points3d = points[img_id]  # (n_joints, 3)
+            points2d = self.project(points3d[np.newaxis, ...]).squeeze()   # project works only in batches
+        elif points.shape[-1] == 2:
+            points2d = points
+        else:
+            raise ValueError(f"Expected points to have shape (..., 2) or (..., 3), but got shape {points.shape}")
+    
         # bones
         if bones is not None:
             for idx, b in enumerate(bones):
-                if self.can_see(img_id, b[0]):
+                if self.can_see(img_id, b[0]) and self.can_see(img_id, b[1]):
                     img = cv2.line(
                         img,
-                        tuple(points[b[0]].astype(int)),
-                        tuple(points[b[1]].astype(int)),
+                        tuple(points2d[b[0]].astype(int)),
+                        tuple(points2d[b[1]].astype(int)),
                         colors[idx] if colors is not None else (128, 0, 0),
                         5,
                     )
@@ -174,7 +185,7 @@ class Camera:
         for jid in range(self.get_njoints()):
             if self.can_see(img_id, jid):
                 img = cv2.circle(
-                    img, tuple(points[jid].T.astype(int)), 5, [0, 0, 128], 5
+                    img, tuple(points2d[jid].T.astype(int)), 5, [0, 0, 128], 5
                 )
 
         return img

--- a/pyba/Camera.py
+++ b/pyba/Camera.py
@@ -139,38 +139,37 @@ class Camera:
             "intr": self.intrinsic,
         }
 
-    def plot_2d(
-        self,
-        img_id: int,
-        points: Optional[np.ndarray] = None,
-        bones: Optional[np.ndarray] = None,
-        colors: Optional[List[Tuple]] = None,
-    ) -> np.ndarray:
+    def plot_2d(self,
+                img_id: int,
+                points2d: Optional[np.ndarray] = None,
+                bones: Optional[np.ndarray] = None,
+                colors: Optional[List[Tuple]] = None) -> np.ndarray:
         """
+        Plot 2D points (and optional bones) on the camera image for `img_id`.
+
         Parameters
         ----------
-        ...
+        img_id : int
+            Index of the image/frame to draw on.
+        points2d : np.ndarray, optional
+            Array of shape (n_joints, 2) giving the 2D points to plot. If
+            None, the camera's stored 2D points for this frame are used. To
+            plot reprojected 3D points instead, use `plot_reprojections`.
+        bones : np.ndarray, optional
+            Array of joint-index pairs defining bones to draw.
+        colors : list of tuples, optional
+            Per-bone RGB colors.
 
-        points: either points2d to plot directly, or points3d in which case they will
-        be projected for plotting.
-
+        Returns
+        -------
+        np.ndarray
+            The image with points and bones drawn on it.
         """
         img = self.get_image(img_id)
 
-        if points is None:
-            
-            points = self.points2d[img_id]
+        if points2d is None:
+            points2d = self.points2d[img_id]
 
-        if points.shape[-1] == 3:
-            # points are given as 3d coords
-            points3d = points[img_id]  # (n_joints, 3)
-            points2d = self.project(points3d[np.newaxis, ...]).squeeze()   # project works only in batches
-        elif points.shape[-1] == 2:
-            points2d = points
-        else:
-            raise ValueError(f"Expected points to have shape (..., 2) or (..., 3), but got shape {points.shape}")
-    
-        # bones
         if bones is not None:
             for idx, b in enumerate(bones):
                 if self.can_see(img_id, b[0]) and self.can_see(img_id, b[1]):
@@ -189,6 +188,42 @@ class Camera:
                 )
 
         return img
+
+    def plot_reprojections(self,
+                           img_id: int,
+                           points3d: np.ndarray,
+                           bones: Optional[np.ndarray] = None,
+                           colors: Optional[List[Tuple]] = None) -> np.ndarray:
+        """
+        Project a set of 3D points into this camera and plot them on the
+        image for `img_id`.
+
+        Parameters
+        ----------
+        img_id : int
+            Index of the image/frame to draw on.
+        points3d : np.ndarray
+            Either a (n_joints, 3) array of 3D points for this frame, or a
+            (T, n_joints, 3) array from which the row at `img_id` will be
+            used.
+        bones : np.ndarray, optional
+            Array of joint-index pairs defining bones to draw.
+        colors : list of tuples, optional
+            Per-bone RGB colors.
+
+        Returns
+        -------
+        np.ndarray
+            The image with reprojected points and bones drawn on it.
+        """
+        if points3d.ndim == 3:
+            points3d = points3d[img_id]
+        elif points3d.ndim != 2:
+            raise ValueError(f'Expected points3d to have shape (n_joints, 3) or '
+                             f'(T, n_joints, 3), but got shape {points3d.shape}')
+        # `project` expects a batch dimension (T, n_joints, 3)
+        points2d = self.project(points3d[np.newaxis, ...]).squeeze(axis=0)
+        return self.plot_2d(img_id, points2d=points2d, bones=bones, colors=colors)
 
     def project(self, points3d: np.ndarray) -> np.ndarray:
         """

--- a/pyba/Camera.py
+++ b/pyba/Camera.py
@@ -142,21 +142,31 @@ class Camera:
     def plot_2d(
         self,
         img_id: int,
-        points2d: Optional[np.ndarray] = None,
+        points: Optional[np.ndarray] = None,
         bones: Optional[np.ndarray] = None,
         colors: Optional[List[Tuple]] = None,
     ) -> np.ndarray:
-        img = self.get_image(img_id)
-        points2d = self.points2d[img_id] if points2d is None else points2d
+        """
+        Parameters
+        ----------
+        ...
 
+        points: either points2d to plot directly, or points3d in which case they will
+        be projected for plotting.
+
+        """
+        img = self.get_image(img_id)
+        points = self.points2d[img_id] if points is None else points[[img_id]]
+        if points.shape[-1] == 3:  # If 3D points are given, project them
+            points = self.project(points).squeeze()
         # bones
         if bones is not None:
             for idx, b in enumerate(bones):
                 if self.can_see(img_id, b[0]):
                     img = cv2.line(
                         img,
-                        tuple(points2d[b[0]].astype(int)),
-                        tuple(points2d[b[1]].astype(int)),
+                        tuple(points[b[0]].astype(int)),
+                        tuple(points[b[1]].astype(int)),
                         colors[idx] if colors is not None else (128, 0, 0),
                         5,
                     )
@@ -164,7 +174,7 @@ class Camera:
         for jid in range(self.get_njoints()):
             if self.can_see(img_id, jid):
                 img = cv2.circle(
-                    img, tuple(points2d[jid].astype(int)), 5, [0, 0, 128], 5
+                    img, tuple(points[jid].T.astype(int)), 5, [0, 0, 128], 5
                 )
 
         return img

--- a/pyba/CameraNetwork.py
+++ b/pyba/CameraNetwork.py
@@ -125,29 +125,19 @@ class CameraNetwork:
         points: Optional[str] = "points2d",
     ) -> np.ndarray:
         """points: which points to plot
-        can be point2d or reprojection
+        can be points2d or reprojection
         """
+        if points == "points2d":
+            panels = [c.plot_2d(img_id, bones=self.bones, colors=self.colors)
+                      for c in self]
+        elif points == "reprojection":
+            panels = [c.plot_reprojections(img_id, self.points3d,
+                                           bones=self.bones, colors=self.colors)
+                      for c in self]
+        else:
+            raise NotImplementedError(f'Unknown points option: {points!r}')
 
-        def get_plot_points2d(cid, img_id, points: str):
-            if points == "points2d":
-                return self[cid][img_id]
-            elif points == "reprojection":
-                return np.squeeze(self[cid].project(self.points3d[[img_id]]))
-            else:
-                raise NotImplementedError
-
-        return np.concatenate(
-            [
-                c.plot_2d(
-                    img_id,
-                    points2d=get_plot_points2d(cid, img_id, points),
-                    bones=self.bones,
-                    colors=self.colors,
-                )
-                for (cid, c) in enumerate(self)
-            ],
-            axis=1,
-        )
+        return np.concatenate(panels, axis=1)
 
     def plot_3d(
         self,


### PR DESCRIPTION
Before, the plot_2d method of the Camera class was used to plot both the 2d video and the 2d part of the 3d video without making being able to re-project the 3d points calculated by triangulation. Because of that, it was plotting the points from 2d pose estimation for both videos. The function was changed so that it can take both 2d and 3d points as argument and then distinguish them based on their dimension. If the argument has 3d points, the method projects them and then plots them. They are transposed when passed in the cv2 functions because those use the (column, row) format